### PR TITLE
fix(ci): add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   quality:
     uses: ./.github/workflows/quality.yaml


### PR DESCRIPTION
## Problem

Release workflow fails with 403 because the default `GITHUB_TOKEN` lacks
permission to create releases.

## Solution

Add `permissions: contents: write` at the workflow level in
`release.yaml`.