### PR TITLE
fix(ci): fix release workflow version and dependency chain

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
           files: artifacts/*
 
   publish:
-    needs: [quality, test]
+    needs: release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vimdoc-language-server"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Barrett Ruth <br@barrettruth.com>"]

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
       {
         packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = "vimdoc-language-server";
-          version = "0.1.0";
+          version = "0.0.1";
           src = ./.;
           cargoLock.lockFile = ./Cargo.lock;
         };


### PR DESCRIPTION
## Problem

`cargo publish` ran in parallel with dist/release and published `0.1.0`
(from `Cargo.toml`) despite the git tag being `v0.0.1`. The `0.1.0`
crate has been yanked.

## Solution

Set version to `0.0.1` in `Cargo.toml` and `flake.nix`. Make `publish`
depend on `release` so the pipeline runs sequentially:
quality → test → dist → release → publish.