### PR TITLE
fix: update Cargo.lock to match version 0.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,7 +319,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vimdoc-language-server"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
## Problem

`Cargo.lock` still recorded version `0.1.0` after the `Cargo.toml`
version bump to `0.0.1`, causing `cargo publish` to fail on CI with
an uncommitted changes error.

## Solution

Regenerate `Cargo.lock` with the correct version.