### PR TITLE
feat: textDocument/foldingRange

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,24 +4,24 @@ use anyhow::{Result, anyhow};
 use clap::{ArgAction, Parser};
 use lsp_server::{Connection, Message, Notification, Response};
 use lsp_types::{
-    DocumentHighlight, DocumentHighlightKind, DocumentSymbol, DocumentSymbolResponse,
-    GotoDefinitionResponse, InitializeParams, Location, OneOf, Position, PublishDiagnosticsParams,
-    Range, ServerCapabilities, SymbolKind, TextDocumentSyncCapability, TextDocumentSyncKind,
-    TextEdit, Uri,
+    DocumentHighlight, DocumentHighlightKind, DocumentSymbol, DocumentSymbolResponse, FoldingRange,
+    FoldingRangeKind, GotoDefinitionResponse, InitializeParams, Location, OneOf, Position,
+    PublishDiagnosticsParams, Range, ServerCapabilities, SymbolKind, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextEdit, Uri,
     notification::{
         DidChangeTextDocument, DidCloseTextDocument, DidOpenTextDocument,
         Notification as LspNotification, PublishDiagnostics,
     },
     request::{
-        DocumentHighlightRequest, DocumentSymbolRequest, Formatting, GotoDefinition,
-        Request as LspRequest,
+        DocumentHighlightRequest, DocumentSymbolRequest, FoldingRangeRequest, Formatting,
+        GotoDefinition, Request as LspRequest,
     },
 };
 use serde::Deserialize;
 
 use vimdoc_language_server::{
     diagnostics, formatter,
-    parser::{Document, Span},
+    parser::{Document, LineKind, Span},
     store::Store,
     tags::TagIndex,
 };
@@ -107,6 +107,7 @@ fn main() -> Result<()> {
         document_symbol_provider: Some(OneOf::Left(true)),
         definition_provider: Some(OneOf::Left(true)),
         document_highlight_provider: Some(OneOf::Left(true)),
+        folding_range_provider: Some(lsp_types::FoldingRangeProviderCapability::Simple(true)),
         ..Default::default()
     })?;
 
@@ -203,6 +204,7 @@ fn handle_request(
         DocumentSymbolRequest::METHOD => handle_document_symbol(req, store),
         GotoDefinition::METHOD => handle_goto_definition(req, store, tag_index),
         DocumentHighlightRequest::METHOD => handle_document_highlight(req, store),
+        FoldingRangeRequest::METHOD => handle_folding_range(req, store),
         _ => Response {
             id: req.id.clone(),
             result: None,
@@ -330,6 +332,81 @@ fn handle_document_highlight(req: &lsp_server::Request, store: &Store) -> Respon
 
             Ok(Some(highlights))
         })();
+    make_response(req, result)
+}
+
+fn handle_folding_range(req: &lsp_server::Request, store: &Store) -> Response {
+    let result = (|| -> Result<Option<Vec<FoldingRange>>> {
+        let params: lsp_types::FoldingRangeParams = serde_json::from_value(req.params.clone())?;
+        let uri = params.text_document.uri;
+        let (_text, doc) = store.get(&uri).ok_or_else(|| anyhow!("unknown uri"))?;
+
+        let mut ranges = Vec::new();
+        let lines = &doc.lines;
+        let total = lines.len();
+
+        let mut section_start: Option<u32> = None;
+        let mut code_start: Option<u32> = None;
+
+        #[allow(clippy::cast_possible_truncation)]
+        for (i, line) in lines.iter().enumerate() {
+            let line_num = i as u32;
+            match &line.kind {
+                LineKind::Separator(_) => {
+                    if let Some(start) = section_start {
+                        if line_num > start + 1 {
+                            ranges.push(FoldingRange {
+                                start_line: start,
+                                start_character: None,
+                                end_line: line_num - 1,
+                                end_character: None,
+                                kind: Some(FoldingRangeKind::Region),
+                                collapsed_text: None,
+                            });
+                        }
+                    }
+                    section_start = Some(line_num);
+                }
+                LineKind::CodeBody => {
+                    if code_start.is_none() {
+                        code_start = Some(line_num);
+                    }
+                }
+                _ => {
+                    if let Some(start) = code_start.take() {
+                        let end = line_num - 1;
+                        if end > start {
+                            ranges.push(FoldingRange {
+                                start_line: start,
+                                start_character: None,
+                                end_line: end,
+                                end_character: None,
+                                kind: Some(FoldingRangeKind::Region),
+                                collapsed_text: None,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        #[allow(clippy::cast_possible_truncation)]
+        if let Some(start) = section_start {
+            let end = (total - 1) as u32;
+            if end > start {
+                ranges.push(FoldingRange {
+                    start_line: start,
+                    start_character: None,
+                    end_line: end,
+                    end_character: None,
+                    kind: Some(FoldingRangeKind::Region),
+                    collapsed_text: None,
+                });
+            }
+        }
+
+        Ok(Some(ranges))
+    })();
     make_response(req, result)
 }
 


### PR DESCRIPTION
## Problem

No folding support in vimdoc files, making large help files hard to navigate.

## Solution

Implement `textDocument/foldingRange` for sections (runs between separator
lines) and code blocks (consecutive `CodeBody` lines).

Stack: depends on #13.