### PR TITLE
feat: textDocument/references

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,8 @@ use lsp_types::{
     },
     request::{
         Completion, DocumentHighlightRequest, DocumentLinkRequest, DocumentSymbolRequest,
-        FoldingRangeRequest, Formatting, GotoDefinition, HoverRequest, Request as LspRequest,
+        FoldingRangeRequest, Formatting, GotoDefinition, HoverRequest, References,
+        Request as LspRequest,
     },
 };
 use serde::Deserialize;
@@ -108,6 +109,7 @@ fn main() -> Result<()> {
         },
         document_symbol_provider: Some(OneOf::Left(true)),
         definition_provider: Some(OneOf::Left(true)),
+        references_provider: Some(OneOf::Left(true)),
         hover_provider: Some(lsp_types::HoverProviderCapability::Simple(true)),
         document_highlight_provider: Some(OneOf::Left(true)),
         folding_range_provider: Some(lsp_types::FoldingRangeProviderCapability::Simple(true)),
@@ -219,6 +221,7 @@ fn handle_request(
         DocumentLinkRequest::METHOD => handle_document_link(req, store, tag_index),
         Completion::METHOD => handle_completion(req, store, tag_index),
         HoverRequest::METHOD => handle_hover(req, store, tag_index),
+        References::METHOD => handle_references(req, store, tag_index),
         _ => Response {
             id: req.id.clone(),
             result: None,
@@ -539,6 +542,40 @@ fn handle_hover(req: &lsp_server::Request, store: &Store, tag_index: &mut TagInd
             }),
             range: None,
         }))
+    })();
+    make_response(req, result)
+}
+
+fn handle_references(req: &lsp_server::Request, store: &Store, tag_index: &TagIndex) -> Response {
+    let result = (|| -> Result<Option<Vec<Location>>> {
+        let params: lsp_types::ReferenceParams = serde_json::from_value(req.params.clone())?;
+        let uri = params.text_document_position.text_document.uri;
+        let pos = params.text_document_position.position;
+        let (_text, doc) = store.get(&uri).ok_or_else(|| anyhow!("unknown uri"))?;
+
+        let Some(name) = tag_name_at(doc, pos) else {
+            return Ok(None);
+        };
+
+        let mut locations: Vec<Location> = tag_index
+            .find_references(&name)
+            .into_iter()
+            .map(|e| Location {
+                uri: e.uri,
+                range: e.range,
+            })
+            .collect();
+
+        if params.context.include_declaration {
+            if let Some(d) = doc.tag_defs().find(|d| d.name == name) {
+                locations.push(Location {
+                    uri: uri.clone(),
+                    range: d.range,
+                });
+            }
+        }
+
+        Ok(Some(locations))
     })();
     make_response(req, result)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@ pub struct ParsedLine {
     pub tag_refs: Vec<Span>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Document {
     pub lines: Vec<ParsedLine>,
 }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -22,6 +22,7 @@ pub struct ExternalTag {
 #[derive(Debug, Default)]
 pub struct TagIndex {
     workspace: HashMap<String, Vec<TagEntry>>,
+    workspace_docs: HashMap<Uri, Document>,
     external: HashMap<String, Vec<ExternalTag>>,
     external_cache: HashMap<PathBuf, Document>,
 }
@@ -43,6 +44,7 @@ impl TagIndex {
                     range: span.range,
                 });
         }
+        self.workspace_docs.insert(uri.clone(), doc.clone());
     }
 
     pub fn remove_file(&mut self, uri: &Uri) {
@@ -50,6 +52,7 @@ impl TagIndex {
             entries.retain(|e| &e.uri != uri);
             !entries.is_empty()
         });
+        self.workspace_docs.remove(uri);
     }
 
     pub fn all_tag_names(&self) -> impl Iterator<Item = &str> {
@@ -57,6 +60,22 @@ impl TagIndex {
             .keys()
             .chain(self.external.keys())
             .map(String::as_str)
+    }
+
+    #[must_use]
+    pub fn find_references(&self, name: &str) -> Vec<TagEntry> {
+        let mut refs = Vec::new();
+        for (uri, doc) in &self.workspace_docs {
+            for span in doc.tag_refs() {
+                if span.name == name {
+                    refs.push(TagEntry {
+                        uri: uri.clone(),
+                        range: span.range,
+                    });
+                }
+            }
+        }
+        refs
     }
 
     pub fn resolve(&mut self, name: &str) -> Option<TagEntry> {


### PR DESCRIPTION
## Problem

No way to find all references to a tag across workspace files.

## Solution

Implement `textDocument/references`. Adds `workspace_docs` cache to `TagIndex`
to store parsed documents for all workspace files, enabling
`find_references()` to search tag_refs across the entire workspace. Respects
`include_declaration` context flag.

Stack: depends on #20.