### PR TITLE
fix: use UTF-16 code units in `text_end_position`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -800,7 +800,10 @@ fn text_end_position(text: &str) -> Position {
             line += 1;
             character = 0;
         } else {
-            character += 1;
+            #[allow(clippy::cast_possible_truncation)]
+            {
+                character += ch.len_utf16() as u32;
+            }
         }
     }
     Position { line, character }


### PR DESCRIPTION
## Problem

`text_end_position` counted Unicode codepoints (`+= 1` per `char`)
instead of UTF-16 code units. LSP positions use UTF-16 offsets, so
non-ASCII characters (emoji, CJK) produced wrong column values,
corrupting `TextEdit` ranges in `handle_formatting`.

## Solution

Replace `character += 1` with `character += ch.len_utf16()` to
correctly count UTF-16 code units per the LSP specification.