### PR TITLE
fix(references): include cross-file declarations with `include_declaration`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -618,11 +618,13 @@ fn handle_references(req: &lsp_server::Request, store: &Store, tag_index: &TagIn
             .collect();
 
         if params.context.include_declaration {
-            if let Some(d) = doc.tag_defs().find(|d| d.name == name) {
-                locations.push(Location {
-                    uri: uri.clone(),
-                    range: d.range,
-                });
+            if let Some(entries) = tag_index.workspace_defs(&name) {
+                for entry in entries {
+                    locations.push(Location {
+                        uri: entry.uri.clone(),
+                        range: entry.range,
+                    });
+                }
             }
         }
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -62,6 +62,11 @@ impl TagIndex {
             .map(String::as_str)
     }
 
+    #[must_use]
+    pub fn workspace_defs(&self, name: &str) -> Option<&Vec<TagEntry>> {
+        self.workspace.get(name)
+    }
+
     pub fn workspace_docs(&self) -> impl Iterator<Item = (&Uri, &Document)> {
         self.workspace_docs.iter()
     }


### PR DESCRIPTION
## Problem

`handle_references` only checked the current file for tag definitions
when `include_declaration` was true. If the cursor was on a `|taglink|`
in file B and the `*tag*` was defined in file A, the definition was
missing from results.

## Solution

Add `workspace_defs()` to `TagIndex` and use it to include all
workspace definitions for the queried tag, not just same-file defs.