### PR TITLE
fix(parser): recognise `>language` code fence as code block start

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -176,6 +176,20 @@ mod tests {
     }
 
     #[test]
+    fn preserves_code_fence_with_language() {
+        let input = "prose\n>lua\n    code()\n<\nafter\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn prose_not_merged_into_code_fence() {
+        let input = "This is prose.\n>lua\n    code()\n<\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
+
+    #[test]
     fn heading_tag_fallback_when_line_too_long() {
         let result = format_document("A very long heading        *tag*\n", 20);
         assert_eq!(result, "A very long heading *tag*\n");

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -81,6 +81,11 @@ fn parse_line(line_num: u32, raw: &str, in_code: &mut bool) -> ParsedLine {
         return mk(LineKind::Separator(SepKind::Minor), vec![], vec![]);
     }
 
+    if is_fence_start(trimmed) {
+        *in_code = true;
+        return mk(LineKind::CodeBody, vec![], vec![]);
+    }
+
     let (tag_defs, tag_refs) = scan_inline(line_num, raw);
 
     if trimmed.ends_with('>') && !trimmed.ends_with("->") {
@@ -97,6 +102,10 @@ fn mk(kind: LineKind, tag_defs: Vec<Span>, tag_refs: Vec<Span>) -> ParsedLine {
         tag_defs,
         tag_refs,
     }
+}
+
+fn is_fence_start(s: &str) -> bool {
+    s.len() > 1 && s.starts_with('>') && s[1..].bytes().all(|b| b.is_ascii_alphabetic())
 }
 
 #[allow(clippy::similar_names)]
@@ -249,6 +258,23 @@ mod tests {
         let span = doc.tag_refs().next().unwrap();
         assert_eq!(span.range.start.character, 3);
         assert_eq!(span.range.end.character, 8);
+    }
+
+    #[test]
+    fn code_fence_language_is_code_body() {
+        let text = "prose\n>lua\n    code()\n<\nafter";
+        let doc = Document::parse(text);
+        assert_eq!(doc.lines[1].kind, LineKind::CodeBody);
+        assert_eq!(doc.lines[2].kind, LineKind::CodeBody);
+        assert_eq!(doc.lines[3].kind, LineKind::CodeBody);
+        assert_eq!(doc.lines[4].kind, LineKind::Text);
+    }
+
+    #[test]
+    fn code_fence_language_no_tags_scanned() {
+        let text = ">vim\n    *not-a-tag*\n<";
+        let doc = Document::parse(text);
+        assert_eq!(doc.tag_defs().count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The parser only activated `in_code` when a prose line ended with `>`.
A standalone `>lua` / `>ruby` / `>vim` delimiter on its own line (the
neovim extended code block syntax) was classified as `LineKind::Text`,
causing the formatter to merge it with the preceding prose line.

## Solution

Add `is_fence_start`, which matches `>` followed by one or more ASCII
alphabetic characters. When matched in `parse_line`, the function sets
`in_code = true` and returns `LineKind::CodeBody`, so the formatter
preserves the line verbatim and correctly parses the code block content
beneath it. Two parser tests and two formatter idempotency tests cover
the new behaviour.

Closes #47.