### PR TITLE
fix(formatter): preserve list items as structural units

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -27,6 +27,10 @@ pub fn format_document(text: &str, line_width: usize) -> String {
                 out.push(raw_lines[i].to_string());
                 i += 1;
             }
+            LineKind::ListItem => {
+                out.push(raw_lines[i].trim_end().to_string());
+                i += 1;
+            }
             LineKind::Text => {
                 if pl.tag_defs.is_empty() {
                     let indent = leading_whitespace(raw_lines[i]);
@@ -193,5 +197,26 @@ mod tests {
     fn heading_tag_fallback_when_line_too_long() {
         let result = format_document("A very long heading        *tag*\n", 20);
         assert_eq!(result, "A very long heading *tag*\n");
+    }
+
+    #[test]
+    fn list_items_not_merged() {
+        let input = "- item 1\n- item 2\n- item 3\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn list_item_not_merged_with_preceding_prose() {
+        let input = "Prose intro.\n- Item.\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn asterisk_list_item_preserved() {
+        let input = "* item text\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -17,6 +17,7 @@ pub enum LineKind {
     Blank,
     Separator(SepKind),
     CodeBody,
+    ListItem,
     Text,
 }
 
@@ -90,6 +91,10 @@ fn parse_line(line_num: u32, raw: &str, in_code: &mut bool) -> ParsedLine {
 
     if trimmed.ends_with('>') && !trimmed.ends_with("->") {
         *in_code = true;
+    }
+
+    if raw.starts_with("- ") || raw.starts_with("* ") || raw.starts_with("• ") {
+        return mk(LineKind::ListItem, tag_defs, tag_refs);
     }
 
     mk(LineKind::Text, tag_defs, tag_refs)
@@ -283,5 +288,31 @@ mod tests {
         let span = doc.tag_defs().next().unwrap();
         assert_eq!(span.range.start.character, 6);
         assert_eq!(span.range.end.character, 11);
+    }
+
+    #[test]
+    fn dash_list_item_is_list_item() {
+        let doc = Document::parse("- item text");
+        assert_eq!(doc.lines[0].kind, LineKind::ListItem);
+    }
+
+    #[test]
+    fn asterisk_list_item_is_list_item() {
+        let doc = Document::parse("* item text");
+        assert_eq!(doc.lines[0].kind, LineKind::ListItem);
+        assert_eq!(doc.tag_defs().count(), 0);
+    }
+
+    #[test]
+    fn tag_def_not_mistaken_for_list_item() {
+        let doc = Document::parse("*my-tag* some text");
+        assert_eq!(doc.lines[0].kind, LineKind::Text);
+        assert_eq!(doc.tag_defs().count(), 1);
+    }
+
+    #[test]
+    fn separator_not_mistaken_for_list_item() {
+        let doc = Document::parse(&"-".repeat(78));
+        assert_eq!(doc.lines[0].kind, LineKind::Separator(SepKind::Minor));
     }
 }


### PR DESCRIPTION
## Problem

The formatter merges list items (`- `, `* `, `• `) into adjacent prose paragraphs. `parse_line` classifies these lines as `LineKind::Text`, so the prose-reflow accumulator in `format_document` collects them alongside regular text and passes everything through `split_whitespace()`, destroying bullet structure.

## Solution

Add `LineKind::ListItem` to the parser. The three bullet prefixes are detected after inline tag scanning (so `*tag*` inside a list item is still indexed, and lines ending with `>` still open code blocks). The formatter emits `ListItem` lines verbatim; the existing reflow loop already stops at non-`Text` lines, so no loop change was needed. `folding_range` and `hover` handlers use `_ =>` wildcards and are unaffected.

Verified against all 135 Neovim runtime docs in `tests/corpus_test.rs` (`formatter_idempotent_on_neovim_corpus`).