### PR TITLE
fix(formatter): preserve tab-aligned command-reference lines

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -35,20 +35,26 @@ pub fn format_document(text: &str, line_width: usize) -> String {
                 if pl.tag_defs.is_empty() {
                     let indent = leading_whitespace(raw_lines[i]);
                     if indent.is_empty() {
-                        let mut j = i;
-                        while j < n
-                            && doc.lines[j].kind == LineKind::Text
-                            && doc.lines[j].tag_defs.is_empty()
-                            && leading_whitespace(raw_lines[j]).is_empty()
-                        {
-                            j += 1;
+                        if raw_lines[i].contains('\t') {
+                            out.push(raw_lines[i].trim_end().to_string());
+                            i += 1;
+                        } else {
+                            let mut j = i;
+                            while j < n
+                                && doc.lines[j].kind == LineKind::Text
+                                && doc.lines[j].tag_defs.is_empty()
+                                && leading_whitespace(raw_lines[j]).is_empty()
+                                && !raw_lines[j].contains('\t')
+                            {
+                                j += 1;
+                            }
+                            let words: Vec<&str> = raw_lines[i..j]
+                                .iter()
+                                .flat_map(|l| l.split_whitespace())
+                                .collect();
+                            reflow_words(&words, line_width, &mut out);
+                            i = j;
                         }
-                        let words: Vec<&str> = raw_lines[i..j]
-                            .iter()
-                            .flat_map(|l| l.split_whitespace())
-                            .collect();
-                        reflow_words(&words, line_width, &mut out);
-                        i = j;
                     } else {
                         out.push(raw_lines[i].trim_end().to_string());
                         i += 1;
@@ -218,5 +224,27 @@ mod tests {
         let input = "* item text\n";
         let result = format_document(input, 78);
         assert_eq!(result, input);
+    }
+
+    #[test]
+    fn tab_command_ref_preserved() {
+        let input = "CTRL-V\t\tInsert next non-digit literally.\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn tab_line_not_merged_with_adjacent_prose() {
+        let input = "Prose before.\nCTRL-V\t\tDescription.\nProse after.\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn tab_idempotent() {
+        let input = "CTRL-V\t\tInsert next non-digit literally.\n\t\tcontinuation line.\n";
+        let once = format_document(input, 78);
+        let twice = format_document(&once, 78);
+        assert_eq!(once, twice);
     }
 }


### PR DESCRIPTION
## Problem

The formatter strips internal tabs from command-reference lines such as `CTRL-V\t\tDescription` in vimdoc help files. These lines have no leading whitespace, so `format_document` treated them as prose and ran them through `split_whitespace()`, which collapses all whitespace including tabs. The resulting output loses the column-alignment that separates command names from their descriptions.

## Solution

In the `LineKind::Text` / no-indent branch, check for an internal `\t` before entering the prose-reflow accumulator and emit the line verbatim. The same guard is added to the while-loop condition so a tab-containing line following prose also breaks accumulation correctly. Continuation lines (leading-tab-indented) were already preserved by the existing indented-line branch.

Verified against all 135 Neovim runtime docs in `tests/corpus_test.rs` (`formatter_idempotent_on_neovim_corpus`).