### PR TITLE
fix(formatter): preserve ordered list items as structural units

### DIFF
--- a/src/formatter.rs
+++ b/src/formatter.rs
@@ -247,4 +247,18 @@ mod tests {
         let twice = format_document(&once, 78);
         assert_eq!(once, twice);
     }
+
+    #[test]
+    fn ordered_list_items_not_merged() {
+        let input = "1. First item\n2. Second item\n3. Third item\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn ordered_list_not_merged_with_prose() {
+        let input = "Intro text.\n1. First item\n2. Second item\n";
+        let result = format_document(input, 78);
+        assert_eq!(result, input);
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -97,6 +97,13 @@ fn parse_line(line_num: u32, raw: &str, in_code: &mut bool) -> ParsedLine {
         return mk(LineKind::ListItem, tag_defs, tag_refs);
     }
 
+    if tag_defs.is_empty() {
+        let after_digits = raw.trim_start_matches(|c: char| c.is_ascii_digit());
+        if after_digits.len() < raw.len() && after_digits.starts_with(". ") {
+            return mk(LineKind::ListItem, tag_defs, tag_refs);
+        }
+    }
+
     mk(LineKind::Text, tag_defs, tag_refs)
 }
 
@@ -314,5 +321,30 @@ mod tests {
     fn separator_not_mistaken_for_list_item() {
         let doc = Document::parse(&"-".repeat(78));
         assert_eq!(doc.lines[0].kind, LineKind::Separator(SepKind::Minor));
+    }
+
+    #[test]
+    fn ordered_list_item_is_list_item() {
+        let doc = Document::parse("1. First item");
+        assert_eq!(doc.lines[0].kind, LineKind::ListItem);
+    }
+
+    #[test]
+    fn multi_digit_ordered_item_is_list_item() {
+        let doc = Document::parse("42. Forty-second item");
+        assert_eq!(doc.lines[0].kind, LineKind::ListItem);
+    }
+
+    #[test]
+    fn version_number_not_list_item() {
+        let doc = Document::parse("3.14 is approximately pi");
+        assert_eq!(doc.lines[0].kind, LineKind::Text);
+    }
+
+    #[test]
+    fn numbered_item_with_tag_not_list_item() {
+        let doc = Document::parse("1. Introduction\t\t\t*intro*");
+        assert_eq!(doc.lines[0].kind, LineKind::Text);
+        assert_eq!(doc.tag_defs().count(), 1);
     }
 }


### PR DESCRIPTION
## Problem

`parse_line` returned `LineKind::Text` for lines starting with `N. ` (digit(s), period, space), causing the prose-reflow accumulator to merge numbered list items into adjacent paragraphs.

## Solution

Extend the `ListItem` detection in `parse_line` to cover ordered list prefixes after the existing unordered check. The `tag_defs.is_empty()` guard prevents numbered TOC heading entries (e.g. `1. Introduction\t\t*tag*`) from being misclassified — they still go through `format_heading` for tag right-alignment.

Closes #54