### PR TITLE
feat: implement textDocument/rangeFormatting

### DIFF
--- a/src/handlers/formatting.rs
+++ b/src/handlers/formatting.rs
@@ -13,11 +13,14 @@ pub fn handle_formatting(req: &lsp_server::Request, store: &Store, config: &Conf
             serde_json::from_value(req.params.clone())?;
         let uri = params.text_document.uri;
         let (text, _doc) = store.get(&uri).ok_or_else(|| anyhow!("unknown uri"))?;
-        let new_text = formatter::format_document(text, &FormatOptions {
-            line_width: config.line_width,
-            reflow: config.reflow,
-            normalize_spacing: config.normalize_spacing,
-        });
+        let new_text = formatter::format_document(
+            text,
+            &FormatOptions {
+                line_width: config.line_width,
+                reflow: config.reflow,
+                normalize_spacing: config.normalize_spacing,
+            },
+        );
         if new_text == text {
             return Ok(None);
         }

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -7,6 +7,7 @@ mod formatting;
 mod highlight;
 mod hover;
 mod prepare_rename;
+mod range_formatting;
 mod references;
 mod rename;
 
@@ -19,5 +20,6 @@ pub use formatting::handle_formatting;
 pub use highlight::handle_document_highlight;
 pub use hover::handle_hover;
 pub use prepare_rename::handle_prepare_rename;
+pub use range_formatting::handle_range_formatting;
 pub use references::handle_references;
 pub use rename::handle_rename;

--- a/src/handlers/range_formatting.rs
+++ b/src/handlers/range_formatting.rs
@@ -1,0 +1,59 @@
+use anyhow::{Result, anyhow};
+use lsp_server::Response;
+use lsp_types::{Position, Range, TextEdit};
+
+use crate::formatter::{self, FormatOptions};
+use crate::server::{Config, make_response, text_end_position};
+use crate::store::Store;
+
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn handle_range_formatting(
+    req: &lsp_server::Request,
+    store: &Store,
+    config: &Config,
+) -> Response {
+    let result = (|| -> Result<Option<Vec<TextEdit>>> {
+        let params: lsp_types::DocumentRangeFormattingParams =
+            serde_json::from_value(req.params.clone())?;
+        let uri = params.text_document.uri;
+        let (text, _doc) = store.get(&uri).ok_or_else(|| anyhow!("unknown uri"))?;
+        let raw_lines: Vec<&str> = text.lines().collect();
+        let n = raw_lines.len();
+
+        let start_line = params.range.start.line as usize;
+        let end_line = (params.range.end.line as usize).min(n.saturating_sub(1));
+
+        if start_line >= n {
+            return Ok(None);
+        }
+
+        let sub_text = raw_lines[start_line..=end_line].join("\n");
+        let opts = FormatOptions {
+            line_width: config.line_width,
+            reflow: config.reflow,
+            normalize_spacing: config.normalize_spacing,
+        };
+        let new_text = formatter::format_document(&sub_text, &opts);
+
+        if new_text == sub_text {
+            return Ok(None);
+        }
+
+        let range_end = text_end_position(raw_lines[end_line]);
+        Ok(Some(vec![TextEdit {
+            range: Range {
+                start: Position {
+                    line: start_line as u32,
+                    character: 0,
+                },
+                end: Position {
+                    line: end_line as u32,
+                    character: range_end.character,
+                },
+            },
+            new_text,
+        }]))
+    })();
+    make_response(req, result)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,11 @@ fn server_capabilities(cli: &Cli) -> ServerCapabilities {
         } else {
             Some(OneOf::Left(true))
         },
+        document_range_formatting_provider: if cli.no_formatting {
+            None
+        } else {
+            Some(OneOf::Left(true))
+        },
         document_symbol_provider: Some(OneOf::Left(true)),
         definition_provider: Some(OneOf::Left(true)),
         references_provider: Some(OneOf::Left(true)),

--- a/src/server.rs
+++ b/src/server.rs
@@ -10,8 +10,8 @@ use lsp_types::{
     },
     request::{
         Completion, DocumentHighlightRequest, DocumentLinkRequest, DocumentSymbolRequest,
-        FoldingRangeRequest, Formatting, GotoDefinition, HoverRequest, References, Rename,
-        Request as LspRequest,
+        FoldingRangeRequest, Formatting, GotoDefinition, HoverRequest, RangeFormatting, References,
+        Rename, Request as LspRequest,
     },
 };
 use serde::Deserialize;
@@ -80,6 +80,9 @@ fn handle_request(
 ) -> Response {
     match req.method.as_str() {
         Formatting::METHOD if config.formatting => handlers::handle_formatting(req, store, config),
+        RangeFormatting::METHOD if config.formatting => {
+            handlers::handle_range_formatting(req, store, config)
+        }
         DocumentSymbolRequest::METHOD => handlers::handle_document_symbol(req, store),
         GotoDefinition::METHOD => handlers::handle_goto_definition(req, store, tag_index),
         DocumentHighlightRequest::METHOD => handlers::handle_document_highlight(req, store),

--- a/tests/corpus_test.rs
+++ b/tests/corpus_test.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use lsp_types::Uri;
 use vimdoc_language_server::{
     diagnostics,
-    formatter::{format_document, FormatOptions},
+    formatter::{FormatOptions, format_document},
     parser::Document,
     tags::TagIndex,
 };

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -753,6 +753,82 @@ mod formatting {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].new_text, "====================\n");
     }
+
+    #[test]
+    fn range_formatting_only_formats_selected_lines() {
+        let mut store = Store::default();
+        let uri: Uri = "file:///test.txt".parse().unwrap();
+        store.open(
+            uri.clone(),
+            "untouched prose line\n==========\nafter\n".into(),
+        );
+
+        let req = Request {
+            id: 1.into(),
+            method: "textDocument/rangeFormatting".into(),
+            params: json!({
+                "textDocument": { "uri": uri.as_str() },
+                "range": {
+                    "start": { "line": 1, "character": 0 },
+                    "end":   { "line": 1, "character": 10 }
+                },
+                "options": { "tabSize": 4, "insertSpaces": true }
+            }),
+        };
+
+        let config = Config {
+            line_width: 78,
+            formatting: true,
+            reflow: ReflowMode::Always,
+            normalize_spacing: false,
+            diagnostics: false,
+            hover: false,
+            runtime_tags: false,
+            tag_paths: vec![],
+        };
+
+        let resp = handlers::handle_range_formatting(&req, &store, &config);
+        let result: Vec<TextEdit> = serde_json::from_value(resp.result.unwrap()).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].range.start.line, 1);
+        assert_eq!(result[0].range.end.line, 1);
+        assert_eq!(result[0].new_text, "=".repeat(78));
+    }
+
+    #[test]
+    fn range_formatting_returns_null_when_already_formatted() {
+        let mut store = Store::default();
+        let uri: Uri = "file:///test.txt".parse().unwrap();
+        store.open(uri.clone(), format!("{}\n", "=".repeat(78)));
+
+        let req = Request {
+            id: 1.into(),
+            method: "textDocument/rangeFormatting".into(),
+            params: json!({
+                "textDocument": { "uri": uri.as_str() },
+                "range": {
+                    "start": { "line": 0, "character": 0 },
+                    "end":   { "line": 0, "character": 78 }
+                },
+                "options": { "tabSize": 4, "insertSpaces": true }
+            }),
+        };
+
+        let config = Config {
+            line_width: 78,
+            formatting: true,
+            reflow: ReflowMode::Always,
+            normalize_spacing: false,
+            diagnostics: false,
+            hover: false,
+            runtime_tags: false,
+            tag_paths: vec![],
+        };
+
+        let resp = handlers::handle_range_formatting(&req, &store, &config);
+        assert_eq!(resp.result, Some(serde_json::Value::Null));
+    }
 }
 
 mod diagnostics_tests {


### PR DESCRIPTION
## Problem

Formatting was all-or-nothing. Users working on files they don't fully own
(e.g. Neovim runtime docs) had to format the entire file or nothing.

## Solution

Adds `handle_range_formatting`. The handler snaps the LSP range to full line
boundaries, extracts those lines, runs `format_document` on the sub-text, and
returns a `TextEdit` replacing only that region. Reuses `FormatOptions` from
`Config` so `--reflow` and `--normalize-spacing` apply identically to both
full and range formatting. The capability is advertised alongside
`documentFormattingProvider` and gated on the same `--no-formatting` flag.

Partially closes #63.