### PR TITLE
feat: implement workspace/symbol for cross-file tag search

### DIFF
--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -10,6 +10,7 @@ mod prepare_rename;
 mod range_formatting;
 mod references;
 mod rename;
+mod workspace_symbol;
 
 pub use completion::handle_completion;
 pub use definition::handle_goto_definition;
@@ -23,3 +24,4 @@ pub use prepare_rename::handle_prepare_rename;
 pub use range_formatting::handle_range_formatting;
 pub use references::handle_references;
 pub use rename::handle_rename;
+pub use workspace_symbol::handle_workspace_symbol;

--- a/src/handlers/workspace_symbol.rs
+++ b/src/handlers/workspace_symbol.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use lsp_server::Response;
+use lsp_types::{Location, SymbolInformation, SymbolKind};
+
+use crate::server::make_response;
+use crate::tags::TagIndex;
+
+#[must_use]
+pub fn handle_workspace_symbol(req: &lsp_server::Request, tag_index: &TagIndex) -> Response {
+    let result = (|| -> Result<Option<Vec<SymbolInformation>>> {
+        let params: lsp_types::WorkspaceSymbolParams = serde_json::from_value(req.params.clone())?;
+        let query = params.query.to_lowercase();
+        let symbols: Vec<SymbolInformation> = tag_index
+            .workspace_entries()
+            .filter(|(name, _)| query.is_empty() || name.to_lowercase().contains(&query))
+            .map(|(name, entry)| {
+                #[allow(deprecated)]
+                SymbolInformation {
+                    name: name.to_string(),
+                    kind: SymbolKind::KEY,
+                    location: Location {
+                        uri: entry.uri.clone(),
+                        range: entry.range,
+                    },
+                    tags: None,
+                    deprecated: None,
+                    container_name: None,
+                }
+            })
+            .collect();
+        Ok(Some(symbols))
+    })();
+    make_response(req, result)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ fn server_capabilities(cli: &Cli) -> ServerCapabilities {
             Some(OneOf::Left(true))
         },
         document_symbol_provider: Some(OneOf::Left(true)),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
         definition_provider: Some(OneOf::Left(true)),
         references_provider: Some(OneOf::Left(true)),
         rename_provider: Some(OneOf::Right(lsp_types::RenameOptions {

--- a/src/server.rs
+++ b/src/server.rs
@@ -83,6 +83,7 @@ fn handle_request(
         RangeFormatting::METHOD if config.formatting => {
             handlers::handle_range_formatting(req, store, config)
         }
+        "workspace/symbol" => handlers::handle_workspace_symbol(req, tag_index),
         DocumentSymbolRequest::METHOD => handlers::handle_document_symbol(req, store),
         GotoDefinition::METHOD => handlers::handle_goto_definition(req, store, tag_index),
         DocumentHighlightRequest::METHOD => handlers::handle_document_highlight(req, store),

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -83,6 +83,12 @@ impl TagIndex {
         self.workspace_docs.iter()
     }
 
+    pub fn workspace_entries(&self) -> impl Iterator<Item = (&str, &TagEntry)> {
+        self.workspace
+            .iter()
+            .flat_map(|(name, entries)| entries.iter().map(move |e| (name.as_str(), e)))
+    }
+
     #[must_use]
     pub fn find_references(&self, name: &str) -> Vec<TagEntry> {
         let mut refs = Vec::new();


### PR DESCRIPTION
## Problem

There was no way to search for a `*tag*` definition by name across the whole
workspace — only per-file `textDocument/documentSymbol` was available.

## Solution

Adds `handle_workspace_symbol` which filters `TagIndex::workspace` by
case-insensitive substring match against the query string, returning
`Vec<SymbolInformation>` with `SymbolKind::KEY` consistent with the document
symbol handler. Empty query returns all workspace tags. A new
`workspace_entries()` iterator on `TagIndex` exposes the private map without
leaking the `HashMap` internals. Capability advertised as
`workspaceSymbolProvider: true`. Partially closes #63.