### PR TITLE
feat(site): TOC sidebar, dark mode code blocks, nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,66 @@
+name: Nightly
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  quality:
+    uses: ./.github/workflows/quality.yaml
+
+  test:
+    uses: ./.github/workflows/test.yaml
+
+  dist:
+    name: Build (${{ matrix.target }})
+    needs: [quality, test]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: vimdoc-language-server-linux-x86_64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: vimdoc-language-server-macos-aarch64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: vimdoc-language-server-macos-x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --target ${{ matrix.target }}
+      - name: Rename binary
+        run: cp target/${{ matrix.target }}/release/vimdoc-language-server ${{ matrix.artifact }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  nightly:
+    needs: dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Move nightly tag
+        run: |
+          git tag -f nightly
+          git push origin nightly --force
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly
+          name: Nightly (${{ github.sha }})
+          prerelease: true
+          make_latest: false
+          files: artifacts/*

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,68 +1,7 @@
 import { defineConfig } from "astro/config";
 import mdx from "@astrojs/mdx";
 import vercel from "@astrojs/vercel";
-
-const midnight = {
-  name: "midnight",
-  type: "dark",
-  colors: {
-    "editor.background": "#121212",
-    "editor.foreground": "#e0e0e0",
-  },
-  tokenColors: [
-    {
-      scope: [
-        "storage.type",
-        "storage.modifier",
-        "keyword.control",
-        "keyword.operator.new",
-      ],
-      settings: { foreground: "#7aa2f7" },
-    },
-    {
-      scope: [
-        "string",
-        "constant",
-        "constant.numeric",
-        "constant.language",
-        "constant.character",
-        "number",
-      ],
-      settings: { foreground: "#98c379" },
-    },
-  ],
-};
-
-const daylight = {
-  name: "daylight",
-  type: "light",
-  colors: {
-    "editor.background": "#f5f5f5",
-    "editor.foreground": "#1a1a1a",
-  },
-  tokenColors: [
-    {
-      scope: [
-        "storage.type",
-        "storage.modifier",
-        "keyword.control",
-        "keyword.operator.new",
-      ],
-      settings: { foreground: "#3b5bdb" },
-    },
-    {
-      scope: [
-        "string",
-        "constant",
-        "constant.numeric",
-        "constant.language",
-        "constant.character",
-        "number",
-      ],
-      settings: { foreground: "#2d7f3e" },
-    },
-  ],
-};
+import { midnight, daylight } from "./src/themes.mjs";
 
 export default defineConfig({
   output: "static",

--- a/site/src/layouts/DocLayout.astro
+++ b/site/src/layouts/DocLayout.astro
@@ -2,9 +2,12 @@
 import "../styles/base.css";
 const fm = Astro.props.frontmatter || Astro.props;
 const title = fm.title;
-const description = fm.description || "vimdoc-language-server documentation";
+const description = fm.description || "help for help files";
+const toc = fm.toc ?? false;
+const headings = Astro.props.headings ?? [];
 const isIndex =
   Astro.url.pathname === "/" || Astro.url.pathname === "/index.html";
+const h2s = headings.filter((h) => h.depth === 2);
 ---
 
 <!doctype html>
@@ -18,7 +21,7 @@ const isIndex =
   <body>
     {
       !isIndex && (
-        <nav>
+        <nav class={toc ? "with-toc" : ""}>
           <a class="title" href="/">
             vimdoc-ls
           </a>
@@ -28,8 +31,27 @@ const isIndex =
       )
     }
 
-    <main>
-      <slot />
-    </main>
+    {
+      toc ? (
+        <div class="page-with-toc">
+          <aside class="toc-nav">
+            <ul>
+              {h2s.map((h) => (
+                <li>
+                  <a href={`#${h.slug}`}>{h.text}</a>
+                </li>
+              ))}
+            </ul>
+          </aside>
+          <main>
+            <slot />
+          </main>
+        </div>
+      ) : (
+        <main>
+          <slot />
+        </main>
+      )
+    }
   </body>
 </html>

--- a/site/src/pages/diagnostics.mdx
+++ b/site/src/pages/diagnostics.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/DocLayout.astro
 title: Diagnostics
+toc: true
 ---
 
 # Diagnostics

--- a/site/src/pages/features.mdx
+++ b/site/src/pages/features.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/DocLayout.astro
 title: Features
+toc: true
 ---
 
 # Features

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,9 +1,13 @@
 ---
+import { Code } from "astro:components";
 import DocLayout from "../layouts/DocLayout.astro";
+import { midnight, daylight } from "../themes.mjs";
 ---
 
-<DocLayout title="">
+<DocLayout title="" description="help for help files">
   <h1>vimdoc-language-server</h1>
+
+  <p class="tagline">help for help files</p>
 
   <p>
     Language server for vim help files. Formatting, diagnostics, navigation,
@@ -19,12 +23,16 @@ import DocLayout from "../layouts/DocLayout.astro";
 
   <h2>Setup</h2>
 
-  <pre><code class="language-lua">vim.lsp.config('vimdoc_ls', &#123;
-  cmd = &#123; 'vimdoc-language-server' &#125;,
-  filetypes = &#123; 'help' &#125;,
-  root_markers = &#123; 'doc', '.git' &#125;,
-&#125;)
-vim.lsp.enable('vimdoc_ls')</code></pre>
+  <Code
+    code={`vim.lsp.config('vimdoc_ls', {
+  cmd = { 'vimdoc-language-server' },
+  filetypes = { 'help' },
+  root_markers = { 'doc', '.git' },
+})
+vim.lsp.enable('vimdoc_ls')`}
+    lang="lua"
+    themes={{ light: daylight, dark: midnight }}
+  />
 
   <h2>Documentation</h2>
 

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -109,6 +109,14 @@ main {
   padding: 3rem clamp(1.25rem, 5vw, 3rem) 6rem;
 }
 
+.tagline {
+  font-size: 1.1rem;
+  opacity: 0.5;
+  margin-top: -0.75rem;
+  margin-bottom: 1.75rem;
+  font-style: italic;
+}
+
 h1 {
   font-weight: 300;
   font-size: clamp(1.75rem, 5vw, 2.5rem);
@@ -179,6 +187,13 @@ pre {
   overflow-x: auto;
   margin-bottom: 1.25rem;
   line-height: 1.5;
+  background: #ebebeb;
+}
+
+@media (prefers-color-scheme: dark) {
+  pre {
+    background: #222222;
+  }
 }
 
 pre code {
@@ -239,6 +254,11 @@ nav {
   font-size: 0.9rem;
 }
 
+nav.with-toc {
+  max-width: calc(13em + 3rem + 42em);
+  padding-left: calc(13em + 3rem + clamp(1.25rem, 5vw, 3rem));
+}
+
 nav a {
   color: inherit;
   text-decoration: none;
@@ -258,4 +278,49 @@ nav .title {
 nav .sep {
   opacity: 0.3;
   margin: 0 0.5em;
+}
+
+.page-with-toc {
+  display: flex;
+  gap: 3rem;
+  max-width: calc(13em + 3rem + 42em);
+  margin: 0 auto;
+  padding: 0 clamp(1.25rem, 5vw, 3rem);
+  align-items: flex-start;
+}
+
+.page-with-toc main {
+  flex: 1;
+  min-width: 0;
+  padding: 3rem 0 6rem;
+}
+
+.toc-nav {
+  width: 13em;
+  flex-shrink: 0;
+  position: sticky;
+  top: 2rem;
+  padding-top: 3rem;
+  font-size: 0.85rem;
+}
+
+.toc-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.toc-nav li {
+  margin-bottom: 0.5rem;
+}
+
+.toc-nav a {
+  color: inherit;
+  text-decoration: none;
+  opacity: 0.5;
+  transition: opacity 0.15s;
+}
+
+.toc-nav a:hover {
+  opacity: 1;
 }

--- a/site/src/themes.mjs
+++ b/site/src/themes.mjs
@@ -1,0 +1,61 @@
+export const midnight = {
+  name: "midnight",
+  type: "dark",
+  colors: {
+    "editor.background": "#222222",
+    "editor.foreground": "#e0e0e0",
+  },
+  tokenColors: [
+    {
+      scope: [
+        "storage.type",
+        "storage.modifier",
+        "keyword.control",
+        "keyword.operator.new",
+      ],
+      settings: { foreground: "#7aa2f7" },
+    },
+    {
+      scope: [
+        "string",
+        "constant",
+        "constant.numeric",
+        "constant.language",
+        "constant.character",
+        "number",
+      ],
+      settings: { foreground: "#98c379" },
+    },
+  ],
+};
+
+export const daylight = {
+  name: "daylight",
+  type: "light",
+  colors: {
+    "editor.background": "#ebebeb",
+    "editor.foreground": "#1a1a1a",
+  },
+  tokenColors: [
+    {
+      scope: [
+        "storage.type",
+        "storage.modifier",
+        "keyword.control",
+        "keyword.operator.new",
+      ],
+      settings: { foreground: "#3b5bdb" },
+    },
+    {
+      scope: [
+        "string",
+        "constant",
+        "constant.numeric",
+        "constant.language",
+        "constant.character",
+        "number",
+      ],
+      settings: { foreground: "#2d7f3e" },
+    },
+  ],
+};


### PR DESCRIPTION
## Problem

Code blocks were invisible (same background as page background in both
themes), the index page had no syntax highlighting, long pages had no
navigation aid, and there was no automated nightly build.

## Solution

Extract Shiki themes to `src/themes.mjs` using canonical midnight/daylight
palette values (`#222222`/`#ebebeb`); add `pre` background for plain code
blocks; wire `<Code>` component on the index page; add optional TOC sidebar
to `DocLayout` (via `toc: true` frontmatter, live on diagnostics and
features); add `nightly.yaml` that force-updates the floating `nightly`
GitHub Release on every push to `main`.