### PR TITLE
fix(site): keep content centered, float TOC in left gutter

### DIFF
--- a/site/src/layouts/DocLayout.astro
+++ b/site/src/layouts/DocLayout.astro
@@ -21,7 +21,7 @@ const h2s = headings.filter((h) => h.depth === 2);
   <body>
     {
       !isIndex && (
-        <nav class={toc ? "with-toc" : ""}>
+        <nav>
           <a class="title" href="/">
             vimdoc-ls
           </a>
@@ -32,26 +32,21 @@ const h2s = headings.filter((h) => h.depth === 2);
     }
 
     {
-      toc ? (
-        <div class="page-with-toc">
-          <aside class="toc-nav">
-            <ul>
-              {h2s.map((h) => (
-                <li>
-                  <a href={`#${h.slug}`}>{h.text}</a>
-                </li>
-              ))}
-            </ul>
-          </aside>
-          <main>
-            <slot />
-          </main>
-        </div>
-      ) : (
-        <main>
-          <slot />
-        </main>
+      toc && (
+        <aside class="toc-nav">
+          <ul>
+            {h2s.map((h) => (
+              <li>
+                <a href={`#${h.slug}`}>{h.text}</a>
+              </li>
+            ))}
+          </ul>
+        </aside>
       )
     }
+
+    <main>
+      <slot />
+    </main>
   </body>
 </html>

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -254,11 +254,6 @@ nav {
   font-size: 0.9rem;
 }
 
-nav.with-toc {
-  max-width: calc(13em + 3rem + 42em);
-  padding-left: calc(13em + 3rem + clamp(1.25rem, 5vw, 3rem));
-}
-
 nav a {
   color: inherit;
   text-decoration: none;
@@ -280,28 +275,18 @@ nav .sep {
   margin: 0 0.5em;
 }
 
-.page-with-toc {
-  display: flex;
-  gap: 3rem;
-  max-width: calc(13em + 3rem + 42em);
-  margin: 0 auto;
-  padding: 0 clamp(1.25rem, 5vw, 3rem);
-  align-items: flex-start;
-}
-
-.page-with-toc main {
-  flex: 1;
-  min-width: 0;
-  padding: 3rem 0 6rem;
-}
-
 .toc-nav {
-  width: 13em;
-  flex-shrink: 0;
-  position: sticky;
-  top: 2rem;
-  padding-top: 3rem;
+  position: fixed;
+  top: 4rem;
+  left: max(1rem, calc(50vw - 21em - 2rem - 11em));
+  width: 11em;
   font-size: 0.85rem;
+}
+
+@media (max-width: 64em) {
+  .toc-nav {
+    display: none;
+  }
 }
 
 .toc-nav ul {


### PR DESCRIPTION
## Problem

The TOC sidebar expanded the total page width and re-centered the
whole assembly, shifting the content column rightward from its original
position.

## Solution

Float the TOC using `position: fixed` calculated from the viewport
center (`50vw - 21em - 2rem - 11em`), so the 42em content column
stays exactly where it always was. TOC hides below 64em viewport
width.