### PR TITLE
fix(site): polish landing page and TOC styling

### DIFF
--- a/site/src/pages/faq.mdx
+++ b/site/src/pages/faq.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/DocLayout.astro
 title: FAQ
+toc: true
 ---
 
 # FAQ

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,7 +1,5 @@
 ---
-import { Code } from "astro:components";
 import DocLayout from "../layouts/DocLayout.astro";
-import { midnight, daylight } from "../themes.mjs";
 ---
 
 <DocLayout title="" description="help for help files">
@@ -15,29 +13,9 @@ import { midnight, daylight } from "../themes.mjs";
     <code>doc/</code>.
   </p>
 
-  <h2>Install</h2>
-
-  <pre><code>cargo install vimdoc-language-server</code></pre>
-
-  <pre><code>nix run github:barrettruth/vimdoc-language-server</code></pre>
-
-  <h2>Setup</h2>
-
-  <Code
-    code={`vim.lsp.config('vimdoc_ls', {
-  cmd = { 'vimdoc-language-server' },
-  filetypes = { 'help' },
-  root_markers = { 'doc', '.git' },
-})
-vim.lsp.enable('vimdoc_ls')`}
-    lang="lua"
-    themes={{ light: daylight as any, dark: midnight as any }}
-  />
-
   <h2>Documentation</h2>
 
   <ul>
-    <li><a href="/installation">Installation</a></li>
     <li><a href="/configuration">Configuration</a></li>
     <li><a href="/features">Features</a></li>
     <li><a href="/diagnostics">Diagnostics</a></li>
@@ -46,9 +24,14 @@ vim.lsp.enable('vimdoc_ls')`}
     <li><a href="/faq">FAQ</a></li>
   </ul>
 
-  <p>
-    <a href="https://github.com/barrettruth/vimdoc-language-server">GitHub</a>
-    <span style="opacity: 0.3; margin: 0 0.5em;">·</span>
-    <a href="https://crates.io/crates/vimdoc-language-server">crates.io</a>
-  </p>
+  <h2>Links</h2>
+
+  <ul>
+    <li>
+      <a href="https://github.com/barrettruth/vimdoc-language-server">GitHub</a>
+    </li>
+    <li>
+      <a href="https://crates.io/crates/vimdoc-language-server">crates.io</a>
+    </li>
+  </ul>
 </DocLayout>

--- a/site/src/pages/vimdoc-syntax.mdx
+++ b/site/src/pages/vimdoc-syntax.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../layouts/DocLayout.astro
 title: Vimdoc syntax
+toc: true
 ---
 
 # Vimdoc syntax

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -280,16 +280,8 @@ nav .sep {
   top: 6rem;
   left: max(1rem, calc(50vw - 23rem - 2rem - 11rem));
   width: 11rem;
-  font-size: 0.85rem;
-  border-left: 1px solid #d0d0d0;
-  padding-left: 0.75rem;
-  line-height: 1.4;
-}
-
-@media (prefers-color-scheme: dark) {
-  .toc-nav {
-    border-left-color: #3d3d3d;
-  }
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 @media (max-width: 64em) {


### PR DESCRIPTION
## Problem

Landing page was too Neovim-forward with inline install/setup sections and a Lua code block. TOC sidebar had a border and was undersized at 0.85rem. FAQ and vimdoc-syntax pages had no table of contents. GitHub/crates.io footer used an informal dot separator.

## Solution

Remove install/setup from index, convert footer to `<h2>Links</h2>` section, add `toc: true` to `faq.mdx` and `vimdoc-syntax.mdx`, bump TOC font to 0.9rem matching the nav tier, and remove `border-left` from `.toc-nav`.