### PR TITLE
fix(ci): auto-patch Cargo.toml version from git tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Set version from tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          sed -i "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
       - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem

`cargo publish` reads the version from `Cargo.toml`, not the git tag. Pushing `v0.0.2` with `Cargo.toml` still at `0.0.1` fails because `0.0.1` already exists on crates.io.

## Solution

Extract version from `GITHUB_REF_NAME`, strip the `v` prefix, and `sed` it into `Cargo.toml` before `cargo publish`.