### PR TITLE
fix(site): match TOC link opacity to breadcrumb nav

### DIFF
--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -318,7 +318,7 @@ nav .sep {
 .toc-nav a {
   color: inherit;
   text-decoration: none;
-  opacity: 0.45;
+  opacity: 0.6;
   transition: opacity 0.15s;
 }
 


### PR DESCRIPTION
## Problem

TOC links at 0.45 opacity are too faint. The breadcrumb subheader uses 0.6 — both are navigation, should share the same weight.

## Solution

Bump `.toc-nav a` opacity from 0.45 to 0.6.