### PR TITLE
fix(site): widen content column to fit 78-char code examples

### DIFF
--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -104,7 +104,7 @@ body {
 }
 
 main {
-  max-width: 46rem;
+  max-width: 50rem;
   margin: 0 auto;
   padding: 3rem clamp(1.25rem, 5vw, 3rem) 6rem;
 }
@@ -250,7 +250,7 @@ hr {
 }
 
 nav {
-  max-width: 46rem;
+  max-width: 50rem;
   margin: 0 auto;
   padding: 1.5rem clamp(1.25rem, 5vw, 3rem) 0;
   font-size: 0.9rem;
@@ -280,7 +280,7 @@ nav .sep {
 .toc-nav {
   position: fixed;
   top: 6.5rem;
-  left: max(1rem, calc(50vw - 23rem - 2rem - 11rem));
+  left: max(1rem, calc(50vw - 25rem - 2rem - 11rem));
   width: 11rem;
   font-size: 0.9rem;
   line-height: 1.5;


### PR DESCRIPTION
## Problem

78-character code examples (separator lines, heading alignment) overflow or scroll at 46rem. The `pre` text area is ~600px but 78 chars of Berkeley Mono at 0.85em needs ~636px.

## Solution

Widen `main` and `nav` from 46rem to 50rem. Update `.toc-nav` left calc from 23rem to 25rem to match.