### PR TITLE
fix(completion): prevent panic on multibyte chars before taglink

### DIFF
--- a/src/handlers/completion.rs
+++ b/src/handlers/completion.rs
@@ -66,11 +66,16 @@ fn is_inside_taglink(text: &str, pos: Position) -> bool {
         return false;
     };
     let col = pos.character as usize;
-    let prefix = if col <= line.len() {
-        &line[..col]
-    } else {
-        line
-    };
-    let pipes = prefix.bytes().filter(|&b| b == b'|').count();
+    let mut utf16_offset = 0;
+    let mut pipes = 0;
+    for ch in line.chars() {
+        if utf16_offset >= col {
+            break;
+        }
+        if ch == '|' {
+            pipes += 1;
+        }
+        utf16_offset += ch.len_utf16();
+    }
     pipes % 2 == 1
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -78,6 +78,37 @@ mod completion {
     }
 
     #[test]
+    fn multibyte_before_taglink_does_not_panic() {
+        let mut store = Store::default();
+        let uri: Uri = "file:///test.txt".parse().unwrap();
+        store.open(uri.clone(), "*foo* heading\n😀|".into());
+
+        let req = Request {
+            id: 1.into(),
+            method: "textDocument/completion".into(),
+            params: json!({
+                "textDocument": { "uri": uri.as_str() },
+                "position": { "line": 1, "character": 3 }
+            }),
+        };
+
+        let tag_index = TagIndex::default();
+        let resp = handlers::handle_completion(&req, &store, &tag_index);
+        let result: CompletionResponse = serde_json::from_value(resp.result.unwrap()).unwrap();
+
+        let labels: Vec<&str> = match &result {
+            CompletionResponse::Array(items) => items.iter().map(|i| i.label.as_str()).collect(),
+            CompletionResponse::List(_) => panic!("expected array"),
+        };
+
+        let expected = expect![[r#"
+            [
+              "foo"
+            ]"#]];
+        expected.assert_eq(&serde_json::to_string_pretty(&labels).unwrap());
+    }
+
+    #[test]
     fn outside_taglink_returns_null() {
         let mut store = Store::default();
         let uri: Uri = "file:///test.txt".parse().unwrap();


### PR DESCRIPTION
## Problem

`is_inside_taglink` used byte-based string slicing (`&line[..col]`) with UTF-16 column positions. A line like `😀|tag|` with cursor at UTF-16 col 3 would try to slice at byte 3, which falls inside the 4-byte emoji, panicking the server.

## Solution

Walk chars accumulating `ch.len_utf16()` to count pipes up to the cursor position. No byte slicing. Adds regression test with emoji before a taglink.