### PR TITLE
refactor(code-action): remove fence language code action

### DIFF
--- a/src/handlers/code_action.rs
+++ b/src/handlers/code_action.rs
@@ -13,8 +13,6 @@ use crate::server::{Config, make_response, text_end_position};
 use crate::store::Store;
 use crate::tags::TagIndex;
 
-const LANGUAGES: &[&str] = &["lua", "vim", "python", "sh", "bash", "c", "go", "rust"];
-
 #[allow(clippy::mutable_key_type)]
 fn make_action(
     title: &str,
@@ -159,75 +157,6 @@ fn collect_separator_convert(
             ));
         }
         _ => {}
-    }
-}
-
-fn find_fence_start(doc: &Document, raw_lines: &[&str], cursor_line: usize) -> Option<usize> {
-    if cursor_line >= doc.lines.len() {
-        return None;
-    }
-    if !matches!(doc.lines[cursor_line].kind, LineKind::CodeBody) {
-        return None;
-    }
-    let mut i = cursor_line;
-    loop {
-        match doc.lines[i].kind {
-            LineKind::CodeBody => {
-                let raw = raw_lines[i].trim_end();
-                if raw.len() > 1
-                    && raw.starts_with('>')
-                    && raw[1..].bytes().all(|b| b.is_ascii_alphabetic())
-                {
-                    return Some(i);
-                }
-            }
-            LineKind::Blank => {}
-            _ => return None,
-        }
-        if i == 0 {
-            return None;
-        }
-        i -= 1;
-    }
-}
-
-#[allow(clippy::cast_possible_truncation)]
-fn collect_fence_language_actions(
-    actions: &mut Vec<CodeActionOrCommand>,
-    doc: &Document,
-    raw_lines: &[&str],
-    cursor_line: usize,
-    _config: &Config,
-    uri: &Uri,
-) {
-    let Some(fence_idx) = find_fence_start(doc, raw_lines, cursor_line) else {
-        return;
-    };
-    let current_lang = raw_lines[fence_idx].trim_end()[1..].to_string();
-    let end_char = text_end_position(raw_lines[fence_idx]).character;
-    let fence_range = Range {
-        start: Position {
-            line: fence_idx as u32,
-            character: 0,
-        },
-        end: Position {
-            line: fence_idx as u32,
-            character: end_char,
-        },
-    };
-    for &lang in LANGUAGES {
-        if lang == current_lang {
-            continue;
-        }
-        actions.push(make_action(
-            &format!("Set code block language: {lang}"),
-            CodeActionKind::REFACTOR,
-            uri,
-            TextEdit {
-                range: fence_range,
-                new_text: format!(">{lang}"),
-            },
-        ));
     }
 }
 
@@ -477,7 +406,6 @@ pub fn handle_code_action(
         let mut actions = Vec::new();
         collect_format_action(&mut actions, doc, &raw_lines, cursor_line, config, &uri);
         collect_separator_convert(&mut actions, doc, &raw_lines, cursor_line, config, &uri);
-        collect_fence_language_actions(&mut actions, doc, &raw_lines, cursor_line, config, &uri);
         collect_taglink_toggle(
             &mut actions,
             doc,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1027,47 +1027,6 @@ mod code_action {
     }
 
     #[test]
-    fn fence_language_offered_on_code_body() {
-        let mut store = Store::default();
-        let uri: Uri = "file:///test.txt".parse().unwrap();
-        store.open(uri.clone(), FIXTURE.into());
-
-        let resp = handlers::handle_code_action(
-            &make_req(8, &uri),
-            &store,
-            &make_config(),
-            &TagIndex::default(),
-        );
-        let result: Vec<CodeActionOrCommand> =
-            serde_json::from_value(resp.result.unwrap()).unwrap();
-        assert_eq!(result.len(), 7);
-    }
-
-    #[test]
-    fn fence_language_current_not_offered() {
-        let mut store = Store::default();
-        let uri: Uri = "file:///test.txt".parse().unwrap();
-        store.open(uri.clone(), FIXTURE.into());
-
-        let resp = handlers::handle_code_action(
-            &make_req(8, &uri),
-            &store,
-            &make_config(),
-            &TagIndex::default(),
-        );
-        let result: Vec<CodeActionOrCommand> =
-            serde_json::from_value(resp.result.unwrap()).unwrap();
-
-        let has_lua = result.iter().any(|a| {
-            let CodeActionOrCommand::CodeAction(ca) = a else {
-                return false;
-            };
-            ca.title == "Set code block language: lua"
-        });
-        assert!(!has_lua);
-    }
-
-    #[test]
     fn already_formatted_returns_empty_actions() {
         let mut store = Store::default();
         let uri: Uri = "file:///test.txt".parse().unwrap();


### PR DESCRIPTION
## Problem

The "Set code block language" code action used a hardcoded `LANGUAGES` list and duplicated `is_fence_start` logic from the parser, which drifted out of sync after #81 added alphanumeric/symbol support to the parser but not the code action handler.

## Solution

Remove `LANGUAGES`, `find_fence_start`, and `collect_fence_language_actions` entirely. Editing a `>lang` fence line is a trivial keystroke — code actions should not clutter the menu with 8 static alternatives.