### PR TITLE
fix(tags): parse tags named `!` and `!!` from tags files

### DIFF
--- a/src/tags.rs
+++ b/src/tags.rs
@@ -173,7 +173,7 @@ pub fn parse_tags_file(path: &Path) -> Result<Vec<(String, ExternalTag)>> {
     let mut entries = Vec::new();
 
     for line in content.lines() {
-        if line.starts_with('!') || line.is_empty() {
+        if line.starts_with("!_TAG_") || line.is_empty() {
             continue;
         }
         let mut parts = line.splitn(3, '\t');


### PR DESCRIPTION
## Problem

`parse_tags_file` skipped any line starting with `!`, intended to filter vim tags metadata comments. But metadata lines use the `!_TAG_` prefix, not bare `!`. Tags named `!` and `!!` (defined in `change.txt`) were silently dropped, causing 5 spurious unresolved-tag diagnostics on the Neovim runtime corpus.

## Solution

Check for `!_TAG_` prefix instead of bare `!`. Corpus false positives drop from 20 to 15 (remaining 15 are genuinely missing tags — netrw/matchit removed from Neovim runtime).