### PR TITLE
docs(site): add Installation link to index page

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -16,6 +16,7 @@ import DocLayout from "../layouts/DocLayout.astro";
   <h2>Documentation</h2>
 
   <ul>
+    <li><a href="/installation">Installation</a></li>
     <li><a href="/configuration">Configuration</a></li>
     <li><a href="/features">Features</a></li>
     <li><a href="/diagnostics">Diagnostics</a></li>


### PR DESCRIPTION
## Problem

The index page listed all documentation pages except Installation.

## Solution

Add the missing link.