### PR TITLE
feat(site): add right-aligned `:h` glyph to docs home header

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,9 +3,10 @@ import DocLayout from "../layouts/DocLayout.astro";
 ---
 
 <DocLayout title="" description="help for help files">
-  <h1>vimdoc-language-server</h1>
-
-  <p class="tagline">help for help files</p>
+  <header>
+    <h1>vimdoc-language-server</h1>
+    <code>:h</code>
+  </header>
 
   <p>
     Language server for vim help files. Formatting, diagnostics, navigation,

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -117,6 +117,23 @@ main {
   font-style: italic;
 }
 
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  gap: 20px;
+  margin-bottom: 1.5rem;
+}
+
+header h1 {
+  margin-bottom: 0;
+}
+
+header code {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+}
+
 h1 {
   font-weight: 300;
   font-size: clamp(1.75rem, 5vw, 2.5rem);


### PR DESCRIPTION
## Problem

The docs home page lacked the visual identity pattern used on barrettruth.com, where a glyph is right-aligned against the page title.

## Solution

Add a `<code>:h</code>` element to a flex header on the index page, sized to match the `h1`. Remove the tagline.