### PR TITLE
feat(site): add right-aligned :h glyph to docs home header

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,9 +3,10 @@ import DocLayout from "../layouts/DocLayout.astro";
 ---
 
 <DocLayout title="" description="help for help files">
-  <h1>vimdoc-language-server</h1>
-
-  <p class="tagline">help for help files</p>
+  <header>
+    <h1>vimdoc-language-server</h1>
+    <code>:h</code>
+  </header>
 
   <p>
     Language server for vim help files. Formatting, diagnostics, navigation,

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -117,6 +117,23 @@ main {
   font-style: italic;
 }
 
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: nowrap;
+  gap: 20px;
+  margin-bottom: 1.5rem;
+}
+
+header h1 {
+  margin-bottom: 0;
+}
+
+header code {
+  font-size: clamp(1.75rem, 5vw, 2.5rem);
+}
+
 h1 {
   font-weight: 300;
   font-size: clamp(1.75rem, 5vw, 2.5rem);


### PR DESCRIPTION
## Problem

The docs site home page header lacks visual connection to vim help file conventions.

## Solution

Add a right-aligned `:h` glyph to the hero header, styled to evoke the vimdoc heading tag alignment pattern.